### PR TITLE
Add CI workflow for Aircraft Safety Tracker test suite

### DIFF
--- a/.github/workflows/ast-ci.yml
+++ b/.github/workflows/ast-ci.yml
@@ -1,0 +1,49 @@
+name: Aircraft Safety Tracker CI
+
+# Runs the test suite on every push/PR that touches this project.
+# Portfolio is a monorepo, so this workflow is scoped with a path filter
+# and a working-directory default rather than living inside the project
+# subfolder itself (GitHub Actions only discovers workflows under the
+# repo-root .github/workflows/, same reason weekly-ingest.yml lives here).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Aircraft Safety Tracker/**"
+      - ".github/workflows/ast-ci.yml"
+  pull_request:
+    paths:
+      - "Aircraft Safety Tracker/**"
+      - ".github/workflows/ast-ci.yml"
+
+concurrency:
+  group: ast-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: "Aircraft Safety Tracker"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "Aircraft Safety Tracker/requirements.txt"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run test suite
+        run: PYTHONPATH=. pytest -q

--- a/Aircraft Safety Tracker/requirements.txt
+++ b/Aircraft Safety Tracker/requirements.txt
@@ -12,3 +12,4 @@ beautifulsoup4==4.12.3
 httpx==0.27.0
 thefuzz==0.22.1
 python-dateutil==2.8.2
+PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ast-ci.yml` to run the 195-test pytest suite automatically on every push/PR touching this project (scoped via path filter, since this is a monorepo).
- Fixes `Aircraft Safety Tracker/requirements.txt`, which was missing `PyYAML` — `url_audit/config.py` imports it directly, so a genuinely clean install (no local dev artifacts) was failing before a single test could run.

## Test plan
- [x] Verified locally in a fresh venv (Python 3.13, clean `pip install -r requirements.txt`): all 195 tests pass (`PYTHONPATH=. pytest -q`).
- [ ] Confirm the new `ast-ci` check goes green on this PR once opened.